### PR TITLE
Fix error handling in STK service: change auth_error to error key in …

### DIFF
--- a/app/Services/MpesaStkService.php
+++ b/app/Services/MpesaStkService.php
@@ -222,13 +222,13 @@ class MpesaStkService
 
         $response = $mpesaAuthService->generateAccessToken($url, $consumerKey, $consumerSecret);
 
-        if (isset($response['auth_error'])) {
+        if (isset($response['error'])) {
 
-            $errorMessage = $response['auth_error'];
+            $errorMessage = $response['error'];
 
             Log::channel('mpesa')->error("STK- Failed to fetch access token: $errorMessage");
 
-            return ['error' => $response['auth_error']];
+            return ['error' => $response['error']];
         }
 
         return $response;


### PR DESCRIPTION
…response

Updated error handling in the STK service to check for 'error' key instead of 'auth_error' when calling  the  get token method