### PR TITLE
fix: Correct log concatenation, rename migration column, and handle e…

### DIFF
--- a/app/Http/Controllers/MpesaDataFetchController.php
+++ b/app/Http/Controllers/MpesaDataFetchController.php
@@ -54,13 +54,21 @@ class MpesaDataFetchController extends Controller
                 $newLastFetchedId = $records->max('id');
 
                 Cache::put($cacheKey, $newLastFetchedId);
+
+                Log::channel('mpesa')->info('C2B_Data_Fetch_Initiated:  ' . $records->max('id'));
+
+                return response()->json([
+                    'status' => 'success',
+                    'data' => $records
+                ], 200);
             }
 
-            Log::channel('mpesa')->info('Fetch_Initiated:  ' - $records->max('id'));
+            Log::channel('mpesa')->info('C2B_Data_Fetch_Initiated: No records found for' . $shortcode);
 
             return response()->json([
                 'status' => 'success',
-                'data' => $records
+                'message' => 'No records found',
+                'data' => []
             ], 200);
         } catch (\Exception $e) {
 
@@ -98,10 +106,21 @@ class MpesaDataFetchController extends Controller
                 ->get();
 
 
-            return response()->json([
-                'status' => 'success',
-                'data' => $records
-            ], 200);
+            if ($records->isNotEmpty()) {
+                Log::channel('mpesa')->info('STK_Data_Fetch_Initiated:  ' . $shortcode);
+                return response()->json([
+                    'status' => 'success',
+                    'data' => $records
+                ], 200);
+            } else {
+                Log::channel('mpesa')->info('STK_Data_Fetch_Initiated: No records found for: ' . $shortcode);
+
+                return response()->json([
+                    'status' => 'success',
+                    'message' => 'No records found',
+                    'data' => []
+                ], 200);
+            }
         } catch (\Exception $e) {
             Log::channel('mpesa')->error('Error fetching STK payments: ' . $e->getMessage());
 

--- a/database/migrations/2024_08_20_105742_create_mpesa_stk_payments_table.php
+++ b/database/migrations/2024_08_20_105742_create_mpesa_stk_payments_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('checkout_request_id')->unique(); 
             $table->string('transaction_id')->nullable();
             $table->string('transaction_date')->nullable();
-            $table->string('shortcode')->nullable(); 
+            $table->string('business_shortcode')->nullable(); 
             $table->unsignedBigInteger('amount')->nullable(); 
             $table->string('msisdn')->nullable();
             $table->timestamps();


### PR DESCRIPTION
…mpty fetch results

- Fixed string concatenation issue in when logging c2b fetch and passing the last fetched id
- Updated migration for mpesa_stk_payments to rename column 'shortcode' to 'business_shortcode'. 
-Enhanced data fetch logic to include a response message and log entry when no records are found